### PR TITLE
Initialize OpenAI Agents starter scaffold

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=YOUR_KEY
+MODEL=gpt-4o-mini
+GITHUB_TOKEN=           # optional, for GitHub tools
+GITHUB_DEFAULT_REPO=    # optional, owner/repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: python -m pip install -r requirements.txt
+      - run: pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["uvicorn","src.app.main:app","--host","0.0.0.0","--port","8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: run api test
+run: ; python -m src.app.cli "help"
+api: ; uvicorn src.app.main:app --reload
+test: ; pytest -q

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Agent-Builder
+# OpenAI Agents Starter
+
+## Overview
+This starter demonstrates core OpenAI Agents SDK primitives including agents, tools, handoffs, guardrails, and sessions. The `Runner.run_sync` helper executes the agent loop end-to-end so you can synchronously evaluate responses in the CLI, HTTP server, or tests.
+
+## Models
+The triage agent defaults to the model specified by the `MODEL` environment variable (defaults to `gpt-4o-mini`). Update the `.env.sample` file or runtime environment to target other supported models.
+
+## Guardrails
+Input and output guardrails register tripwires via the SDK decorators. `safety_gate` rejects destructive or credential-related prompts, while `json_gate` ensures structured responses are neither empty nor overly long.
+
+## Tools and Handoffs
+Function tools decorated with `@function_tool` empower agents with capabilities such as fetching README files or creating GitHub issues. The triage agent can hand off to the specialized GitOps agent whenever issue tracking is needed, enabling delegated workflows.
+
+## GitHub Integration
+To enable the `create_github_issue` tool, set `GITHUB_TOKEN` and `GITHUB_DEFAULT_REPO` in your environment. Without a token the tool returns an informative message instead of raising.
+
+## Run the Agent
+- CLI: `python -m src.app.cli "open an issue: bug in onboarding flow"`
+- API: `uvicorn src.app.main:app --reload` then POST `{ "input": "..." }` to `/run`.
+
+## Tracing and Observability
+The Agents SDK ships with tracing, logging, and run configuration hooks. Refer to the SDK documentation for enabling advanced telemetry or external observers in production.
+
+## Safety and Operations
+Never hardcode secrets; rely on environment variables or secret managers. Deploy behind a process manager to enforce rate limits and graceful restarts for sustained workloads.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "openai-agents-starter"
+version = "0.1.0"
+description = "Minimal production-ready agent using OpenAI Agents SDK"
+authors = [{ name = "OpenAI Agents Starter" }]
+requires-python = ">=3.11"
+dependencies = [
+    "openai-agents>=0.1.0",
+    "pydantic>=2.7",
+    "httpx>=0.27",
+    "fastapi>=0.112",
+    "uvicorn>=0.30",
+    "python-dotenv>=1.0",
+]
+[project.optional-dependencies]
+dev = ["pytest>=8.3"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+openai-agents>=0.1.0
+pydantic>=2.7
+httpx>=0.27
+fastapi>=0.112
+uvicorn>=0.30
+python-dotenv>=1.0
+pytest>=8.3

--- a/src/agents/github_tools.py
+++ b/src/agents/github_tools.py
@@ -1,0 +1,26 @@
+import os, httpx
+from agents import function_tool
+
+
+@function_tool
+async def create_github_issue(repo: str, title: str, body: str = "") -> str:
+    """Create a GitHub issue in owner/repo. Requires GITHUB_TOKEN env. Returns status and URL."""
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        return "missing GITHUB_TOKEN"
+    async with httpx.AsyncClient(timeout=20) as client:
+        r = await client.post(
+            f"https://api.github.com/repos/{repo}/issues",
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+            json={"title": title, "body": body},
+        )
+        data = r.json() if r.content else {}
+        return f"{r.status_code} {data.get('html_url','')}"
+
+
+@function_tool
+async def get_repo_readme(repo: str) -> str:
+    """Fetch README.md text for owner/repo main branch via GitHub API."""
+    async with httpx.AsyncClient(timeout=20) as client:
+        r = await client.get(f"https://raw.githubusercontent.com/{repo}/main/README.md")
+        return r.text if r.status_code == 200 else f"error {r.status_code}"

--- a/src/agents/guardrails.py
+++ b/src/agents/guardrails.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel
+from agents import (
+    Agent, Runner,
+    GuardrailFunctionOutput,
+    RunContextWrapper, TResponseInputItem,
+    input_guardrail, output_guardrail,
+)
+
+
+class MessageOut(BaseModel):
+    response: str
+
+
+@input_guardrail
+async def safety_gate(ctx: RunContextWrapper[None], agent: Agent, input: str | list[TResponseInputItem]) -> GuardrailFunctionOutput:
+    """Trip if user requests destructive ops or credentials."""
+    text = input if isinstance(input, str) else " ".join([i.input_text or "" for i in input])  # tolerate list inputs
+    banned = ("delete repo", "share password", "drop database")
+    trip = any(k in text.lower() for k in banned)
+    return GuardrailFunctionOutput(output_info={"banned_hit": trip}, tripwire_triggered=trip)
+
+
+@output_guardrail
+async def json_gate(ctx: RunContextWrapper[None], agent: Agent, output: MessageOut) -> GuardrailFunctionOutput:
+    """Trip if response is empty or overlong."""
+    trip = (not output.response) or (len(output.response) > 5000)
+    return GuardrailFunctionOutput(output_info={"len": len(output.response) if output.response else 0}, tripwire_triggered=trip)

--- a/src/agents/triage.py
+++ b/src/agents/triage.py
@@ -1,0 +1,51 @@
+import os
+from typing import Literal
+from pydantic import BaseModel
+from agents import Agent, Runner, handoff
+from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
+from .guardrails import safety_gate, json_gate
+from .github_tools import create_github_issue, get_repo_readme
+
+
+class Outcome(BaseModel):
+    kind: Literal["answer","issue_created","unknown"]
+    summary: str
+    actions: list[str] = []
+
+
+# Specialized GitOps agent that focuses on issues
+gitops_agent = Agent(
+    name="GitOps",
+    instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
+You help create concise GitHub issues. When asked to open an issue, call the create_github_issue tool with:
+- repo: from context env GITHUB_DEFAULT_REPO unless user specifies owner/repo
+- title: 6–10 words, imperative
+- body: short context, acceptance criteria checklist.
+Return the created issue URL in your final text.""",
+    model=os.getenv("MODEL","gpt-4o-mini"),
+    tools=[create_github_issue],
+)
+
+
+# Primary triage agent
+triage_agent = Agent(
+    name="Triage",
+    instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
+You are a deterministic assistant for planning and light GitOps. 
+Use tools when necessary. Prefer answering directly. 
+If the user asks to open an issue or track work, HANDOFF to GitOps.
+When asked about a repo, use get_repo_readme.
+Output must be a one-paragraph summary of up to 120 words.""",
+    model=os.getenv("MODEL","gpt-4o-mini"),
+    tools=[get_repo_readme],
+    handoffs=[handoff(gitops_agent)],        # enable delegation to GitOps
+    input_guardrails=[safety_gate],
+    output_guardrails=[json_gate],
+    output_type=Outcome,                      # enforce structured final output
+)
+
+
+def run_sync(user_input: str) -> Outcome:
+    """Run the triage agent and return the structured Outcome."""
+    result = Runner.run_sync(triage_agent, user_input)
+    return result.final_output

--- a/src/app/cli.py
+++ b/src/app/cli.py
@@ -1,0 +1,15 @@
+import sys
+from dotenv import load_dotenv
+from agents import Runner
+from agents.triage import triage_agent
+
+
+def main():
+    load_dotenv()
+    prompt = " ".join(sys.argv[1:]) or "help"
+    result = Runner.run_sync(triage_agent, prompt)
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,21 @@
+from typing import Any, Dict
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from dotenv import load_dotenv
+from agents import Runner
+from agents.triage import triage_agent
+
+load_dotenv()
+app = FastAPI(title="Agents SDK Starter")
+
+
+class RunRequest(BaseModel):
+    input: str
+
+
+@app.post("/run")
+def run(req: RunRequest) -> Dict[str, Any]:
+    if not req.input:
+        raise HTTPException(400, "input required")
+    result = Runner.run_sync(triage_agent, req.input)
+    return {"output": result.final_output}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,5 @@
+from agents.triage import run_sync
+
+def test_smoke():
+    out = run_sync("Summarize this repo starter in 1 sentence.")
+    assert hasattr(out, "summary")


### PR DESCRIPTION
## Summary
- add triage-focused agent with guardrails, GitHub tools, and handoff-enabled GitOps helper
- expose Runner integration via CLI, FastAPI service, and supporting documentation
- configure project tooling including requirements, Dockerfile, CI workflow, and smoke test

## Testing
- not run (OpenAI Agents SDK requires external services)


------
https://chatgpt.com/codex/tasks/task_e_68d6d4d49bb0832c92cd1aba60cb16c9