### PR TITLE
Add OpenAI Agents starter scaffold

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=YOUR_KEY
+MODEL=gpt-4o-mini
+GITHUB_TOKEN=            # optional, repo:issues scope
+GITHUB_DEFAULT_REPO=     # optional, e.g. stevenschling13/Agent-Builder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      CI: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install -r requirements.txt
+      - run: pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8000
+CMD ["uvicorn","src.app.main:app","--host","0.0.0.0","--port","8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: run api test
+run: ; python -m src.app.cli "help"
+api: ; uvicorn src.app.main:app --reload
+test: ; pytest -q

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Agent-Builder
+# OpenAI Agents SDK Starter
+
+## What you get
+- Python starter using the OpenAI Agents SDK with tools, handoffs, and guardrails.
+- CLI and FastAPI server.
+- Optional GitHub issue tool.
+
+## Quickstart
+```bash
+cp .env.sample .env   # add OPENAI_API_KEY, optional GitHub vars
+python -m pip install -r requirements.txt
+python -m src.app.cli "help"
+uvicorn src.app.main:app --reload
+curl -s -X POST localhost:8000/run -H "Content-Type: application/json" -d '{"input":"open an issue: onboarding bug"}'
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+openai-agents>=0.0.19
+pydantic>=2.7
+httpx>=0.27
+fastapi>=0.112
+uvicorn>=0.30
+python-dotenv>=1.0
+pytest>=8.2

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,1 @@
+# Marks agents package for imports in src/ layout.

--- a/src/agents/github_tools.py
+++ b/src/agents/github_tools.py
@@ -1,0 +1,26 @@
+import os, httpx
+from agents import function_tool
+
+
+@function_tool
+async def create_github_issue(repo: str, title: str, body: str = "") -> str:
+    """Create a GitHub issue in owner/repo. Requires env GITHUB_TOKEN. Returns 'STATUS URL'."""
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        return "missing GITHUB_TOKEN"
+    async with httpx.AsyncClient(timeout=20) as client:
+        r = await client.post(
+            f"https://api.github.com/repos/{repo}/issues",
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+            json={"title": title, "body": body},
+        )
+        j = r.json() if r.content else {}
+        return f"{r.status_code} {j.get('html_url','')}"
+
+
+@function_tool
+async def get_repo_readme(repo: str) -> str:
+    """Fetch README.md from the repo main branch via raw.githubusercontent.com."""
+    async with httpx.AsyncClient(timeout=20) as client:
+        r = await client.get(f"https://raw.githubusercontent.com/{repo}/main/README.md")
+        return r.text if r.status_code == 200 else f"error {r.status_code}"

--- a/src/agents/guardrails.py
+++ b/src/agents/guardrails.py
@@ -1,0 +1,31 @@
+from typing import Any
+from pydantic import BaseModel
+from agents import (
+    Agent,
+    GuardrailFunctionOutput,
+    RunContextWrapper,
+    TResponseInputItem,
+    input_guardrail,
+    output_guardrail,
+)
+
+
+class MessageOut(BaseModel):
+    response: str
+
+
+@input_guardrail
+async def safety_gate(ctx: RunContextWrapper[None], agent: Agent, user_input: str | list[TResponseInputItem]) -> GuardrailFunctionOutput:
+    """Trip on destructive ops or credential sharing."""
+    text = user_input if isinstance(user_input, str) else " ".join([(i.input_text or "") for i in user_input])
+    banned = ("delete repo", "share password", "drop database", "wipe data")
+    hit = any(k in text.lower() for k in banned)
+    return GuardrailFunctionOutput(output_info={"banned_hit": hit}, tripwire_triggered=hit)
+
+
+@output_guardrail
+async def json_gate(ctx: RunContextWrapper[None], agent: Agent, output: MessageOut) -> GuardrailFunctionOutput:
+    """Trip if empty or excessive length."""
+    length = len(output.response) if getattr(output, "response", None) else 0
+    hit = (length == 0) or (length > 5000)
+    return GuardrailFunctionOutput(output_info={"len": length}, tripwire_triggered=hit)

--- a/src/agents/triage.py
+++ b/src/agents/triage.py
@@ -1,0 +1,47 @@
+import os
+from typing import Literal
+from pydantic import BaseModel
+from agents import Agent, Runner, handoff
+from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
+from .guardrails import safety_gate, json_gate, MessageOut
+from .github_tools import create_github_issue, get_repo_readme
+
+
+class Outcome(BaseModel):
+    kind: Literal["answer","issue_created","unknown"]
+    summary: str
+    actions: list[str] = []
+
+
+gitops_agent = Agent(
+    name="GitOps",
+    instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
+You help create concise GitHub issues. When asked to open an issue, call create_github_issue with:
+- repo: from env GITHUB_DEFAULT_REPO unless user specifies owner/repo
+- title: 6–10 words, imperative
+- body: short context + acceptance criteria checklist.
+Return the created issue URL in your final text.""",
+    model=os.getenv("MODEL","gpt-4o-mini"),
+    tools=[create_github_issue],
+)
+
+
+triage_agent = Agent(
+    name="Triage",
+    instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
+You are a deterministic planner and light GitOps assistant.
+Prefer direct answers. When asked to open an issue, HANDOFF to GitOps.
+Use get_repo_readme when the user asks about a repo.
+Respond with one paragraph <=120 words.""",
+    model=os.getenv("MODEL","gpt-4o-mini"),
+    tools=[get_repo_readme],
+    handoffs=[handoff(gitops_agent)],
+    input_guardrails=[safety_gate],
+    output_guardrails=[json_gate],
+    output_type=Outcome,
+)
+
+
+def run_sync(user_input: str) -> Outcome:
+    """Synchronous helper for CLI contexts."""
+    return Runner.run_sync(triage_agent, user_input).final_output

--- a/src/app/cli.py
+++ b/src/app/cli.py
@@ -1,0 +1,15 @@
+import os, sys
+from dotenv import load_dotenv
+from agents import Runner
+from agents.triage import triage_agent
+
+
+def main():
+    load_dotenv()
+    prompt = " ".join(sys.argv[1:]) or "help"
+    result = Runner.run_sync(triage_agent, prompt)
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,23 @@
+import os
+from typing import Any, Dict
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from dotenv import load_dotenv
+from agents import Runner
+from agents.triage import triage_agent
+
+load_dotenv()
+app = FastAPI(title="Agents SDK Starter")
+
+
+class RunRequest(BaseModel):
+    input: str
+
+
+@app.post("/run")
+async def run(req: RunRequest) -> Dict[str, Any]:
+    if not req.input:
+        raise HTTPException(400, "input required")
+    # Use async API per SDK guidance; do not call run_sync inside async context.
+    result = await Runner.run(triage_agent, req.input)
+    return {"output": result.final_output}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,8 @@
+import os, pytest
+from agents.triage import run_sync
+
+
+@pytest.mark.skipif(os.getenv("CI")=="true", reason="skip network on CI")
+def test_smoke():
+    out = run_sync("Summarize this starter in 1 sentence.")
+    assert hasattr(out, "summary")


### PR DESCRIPTION
## Summary
- scaffold a Python starter that wires the OpenAI Agents SDK with guardrails, tools, and handoffs
- provide CLI and FastAPI entrypoints plus Dockerfile, Makefile, and CI workflow
- add optional GitHub issue helper tools and smoke test

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d88dd4fc832c8e5474f1462ac14d