### PR TITLE
Add Gmail triage agent using OpenAI Agents SDK

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+OPENAI_API_KEY=YOUR_KEY
+MODEL=gpt-4o-mini
+# Gmail OAuth scopes: readonly for fetch, compose for drafts
+GMAIL_SCOPES=https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.compose
+# Optional defaults for tools
+GMAIL_DEFAULT_QUERY=is:unread
+GMAIL_DEFAULT_LABEL=INBOX
+AGENT_MAX_TURNS=8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env: { CI: "true" }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: python -m pip install -r requirements.txt
+      - run: pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+EXPOSE 8000
+CMD ["uvicorn","src.app.main:app","--host","0.0.0.0","--port","8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: run api test
+run: ; python -m src.app.cli "Help"
+api: ; uvicorn src.app.main:app --reload
+test: ; pytest -q

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Agent-Builder
+# OpenAI Gmail Agent
+## Modes
+- Tool mode: Agent uses Gmail tools to list messages by label or query, fetch a message, and create drafts (new or reply).
+- Paste mode: Provide raw content via `/run` input.
+## Gmail auth
+- Place `credentials.json` in repo root (OAuth client). First run creates `token.json`. Scopes from `GMAIL_SCOPES`. For drafts you need `gmail.compose` or `gmail.modify`.
+## Quickstart
+```bash
+cp .env.sample .env
+python -m pip install -r requirements.txt
+# first-run OAuth will open a browser to consent
+python -m src.app.cli "List 3 unread in INBOX using list_messages and then summarize each."
+uvicorn src.app.main:app --reload
+curl -s -X POST localhost:8000/run -H "Content-Type: application/json" \
+  -d '{"input":"Fetch latest unread with list_messages, then for msg <ID> propose three replies and create a draft reply to the sender."}'
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+openai-agents>=0.2.8
+fastapi>=0.112
+uvicorn>=0.30
+pydantic>=2.7
+python-dotenv>=1.0
+httpx>=0.27
+google-api-python-client>=2.143
+google-auth-httplib2>=0.2
+google-auth-oauthlib>=1.2
+pytest>=8.2

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,1 @@
+# marks agents package

--- a/src/agents/gmail_tools.py
+++ b/src/agents/gmail_tools.py
@@ -1,0 +1,94 @@
+import os, base64, time, re
+from typing import Optional, List, Dict, Any
+from email.message import EmailMessage
+from agents import function_tool
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+
+SCOPES = tuple(s.strip() for s in os.getenv("GMAIL_SCOPES","https://www.googleapis.com/auth/gmail.readonly").split(","))
+
+
+def _gmail_service():
+    """OAuth desktop flow using credentials.json; caches token.json."""
+    creds = None
+    if os.path.exists("token.json"):
+        creds = Credentials.from_authorized_user_file("token.json", SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open("token.json","w") as f:
+            f.write(creds.to_json())
+    return build("gmail","v1", credentials=creds)
+
+
+@function_tool
+async def list_messages(label: str = None, query: str = None, max_results: int = 5) -> List[str]:
+    """Return message IDs from the user's mailbox based on label and/or query."""
+    service = _gmail_service()
+    kwargs = {"userId":"me","maxResults":max_results}
+    if label: kwargs["labelIds"] = [label]
+    if query: kwargs["q"] = query
+    resp = service.users().messages().list(**kwargs).execute()
+    return [m["id"] for m in resp.get("messages",[])]
+
+
+@function_tool
+async def get_message(msg_id: str) -> Dict[str, Any]:
+    """Fetch a message in 'full' format. Returns headers, snippet, body_text, threadId."""
+    service = _gmail_service()
+    m = service.users().messages().get(userId="me", id=msg_id, format="full").execute()
+    headers = {h["name"].lower(): h["value"] for h in m["payload"].get("headers", [])}
+
+    def _walk(payload):
+        if payload.get("body",{}).get("data"):
+            try: return base64.urlsafe_b64decode(payload["body"]["data"]).decode(errors="ignore")
+            except Exception: return ""
+        for p in payload.get("parts",[]) or []:
+            t = _walk(p)
+            if t: return t
+        return ""
+
+    body_text = _walk(m["payload"])
+    return {"id": m["id"], "threadId": m.get("threadId"), "headers": headers, "snippet": m.get("snippet",""), "body_text": body_text}
+
+
+def _mime_new(to: str, subject: str, body: str, sender: Optional[str] = None) -> str:
+    msg = EmailMessage()
+    msg.set_content(body)
+    if sender: msg["From"] = sender
+    msg["To"] = to
+    msg["Subject"] = subject
+    return base64.urlsafe_b64encode(msg.as_bytes()).decode()
+
+
+def _mime_reply(to: str, subject: str, body: str, in_reply_to: str, references: str) -> str:
+    msg = EmailMessage()
+    msg.set_content(body)
+    msg["To"] = to
+    msg["Subject"] = subject
+    msg["In-Reply-To"] = in_reply_to
+    msg["References"] = references
+    return base64.urlsafe_b64encode(msg.as_bytes()).decode()
+
+
+@function_tool
+async def create_draft_new(to: str, subject: str, body: str) -> Dict[str,str]:
+    """Create a new draft email."""
+    service = _gmail_service()
+    raw = _mime_new(to, subject, body)
+    draft = service.users().drafts().create(userId="me", body={"message":{"raw": raw}}).execute()
+    return {"draft_id": draft["id"], "message_id": draft["message"]["id"]}
+
+
+@function_tool
+async def create_draft_reply(thread_id: str, to: str, subject: str, body: str, in_reply_to: str) -> Dict[str,str]:
+    """Create a reply draft in an existing thread. Requires In-Reply-To Message-ID."""
+    service = _gmail_service()
+    raw = _mime_reply(to, subject, body, in_reply_to=in_reply_to, references=in_reply_to)
+    draft = service.users().drafts().create(userId="me", body={"message":{"raw": raw, "threadId": thread_id}}).execute()
+    return {"draft_id": draft["id"], "message_id": draft["message"]["id"]}

--- a/src/agents/gmail_triage.py
+++ b/src/agents/gmail_triage.py
@@ -1,0 +1,43 @@
+import os
+from typing import Literal
+from pydantic import BaseModel
+from agents import Agent, Runner, handoff
+from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
+from .guardrails import safety_gate, json_gate, TriageOut
+from .gmail_tools import list_messages, get_message, create_draft_new, create_draft_reply
+
+
+class GmailResult(BaseModel):
+    kind: Literal["analysis","draft_created","none"]
+    payload: dict
+
+
+triage_agent = Agent(
+    name="GmailTriage",
+    instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
+You triage Gmail messages and produce a deterministic summary, priority, actions, and three reply drafts.
+Taxonomy:
+- Action Required {{Approval|Info Request|Deliverable|Follow-up}}
+- Scheduling {{Meeting Request|Reschedule|Availability}}
+- Sales/Finance {{Invoice/Bill|Payment|Pricing|Contract}}
+- Recruiting/Career {{Recruiter|Interview|Offer|HR}}
+- Operations {{Customer|Vendor|Internal Update}}
+- Notifications {{Receipt|System Alert}}
+- Personal/Other
+- Low-Value/Spam/Phishing
+Scoring:
+P = base(From:known=20|org=10|else=0) + intent(25|10|0) + time(≤48h=20|≤7d=10|0) + entities(+10 each money/date/attachment ≤20) + thread_depth(≥3=+10) − ambiguity(10) − risk(30).
+Urgency: High if P≥80; Medium if 50–79; else Low.
+Output TriageOut with fields filled. If risk, do not propose links or payments.""",
+    model=os.getenv("MODEL","gpt-4o-mini"),
+    tools=[list_messages, get_message, create_draft_new, create_draft_reply],
+    input_guardrails=[safety_gate],
+    output_guardrails=[json_gate],
+    output_type=TriageOut,
+)
+
+
+def run_sync(user_input: str) -> GmailResult:
+    """Synchronous helper."""
+    out = Runner.run_sync(triage_agent, user_input).final_output
+    return GmailResult(kind="analysis", payload=out.model_dump())

--- a/src/agents/guardrails.py
+++ b/src/agents/guardrails.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+from agents import Agent, GuardrailFunctionOutput, RunContextWrapper, TResponseInputItem, input_guardrail, output_guardrail
+
+
+class TriageOut(BaseModel):
+    category: str
+    subcategory: str | None = None
+    priority: int
+    urgency: str
+    summary: str
+    actions: list[str] = []
+    reply_quick: str
+    reply_professional: str
+    reply_detailed: str
+    json_payload: dict
+    confidence: float
+
+
+@input_guardrail
+async def safety_gate(ctx: RunContextWrapper[None], agent: Agent, user_input: str | list[TResponseInputItem]) -> GuardrailFunctionOutput:
+    text = user_input if isinstance(user_input, str) else " ".join([(i.input_text or "") for i in user_input])
+    banned = ("share password","wire funds","send credentials","delete repo","drop database")
+    hit = any(k in text.lower() for k in banned)
+    return GuardrailFunctionOutput(output_info={"banned": hit}, tripwire_triggered=hit)
+
+
+@output_guardrail
+async def json_gate(ctx: RunContextWrapper[None], agent: Agent, output: TriageOut) -> GuardrailFunctionOutput:
+    ok = bool(getattr(output, "summary", "")) and 0 <= getattr(output, "confidence", 0) <= 1
+    return GuardrailFunctionOutput(output_info={"ok": ok}, tripwire_triggered=(not ok))

--- a/src/app/cli.py
+++ b/src/app/cli.py
@@ -1,0 +1,15 @@
+import sys
+from dotenv import load_dotenv
+from agents import Runner
+from agents.gmail_triage import triage_agent
+
+
+def main():
+    load_dotenv()
+    prompt = " ".join(sys.argv[1:]) or "Help"
+    result = Runner.run_sync(triage_agent, prompt)
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from dotenv import load_dotenv
+from agents import Runner
+from agents.gmail_triage import triage_agent
+
+load_dotenv()
+app = FastAPI(title="OpenAI Gmail Agent")
+
+
+class RunRequest(BaseModel):
+    input: str
+
+
+@app.post("/run")
+async def run(req: RunRequest):
+    if not req.input:
+        raise HTTPException(400, "input required")
+    result = await Runner.run(triage_agent, req.input)
+    return {"output": result.final_output}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,8 @@
+import os, pytest
+from agents.gmail_triage import run_sync
+
+
+@pytest.mark.skipif(os.getenv("CI")=="true", reason="skip network on CI")
+def test_smoke():
+    out = run_sync("Classify and propose replies for a generic scheduling email.")
+    assert "summary" in out.payload


### PR DESCRIPTION
## Summary
- implement Gmail triage agent with guardrails and Gmail API tool wrappers
- add FastAPI service, CLI entry point, and Docker/Makefile helpers
- provide smoke test, CI workflow, and documentation for setup

## Testing
- not run (requires OpenAI credentials)

------
https://chatgpt.com/codex/tasks/task_e_68d6dc543530832c92ea7efc16a1055e